### PR TITLE
加入拖拽生成密码功能

### DIFF
--- a/index.html
+++ b/index.html
@@ -6,7 +6,7 @@
   <title>Wsine - 觅密</title>
   <link type="text/css" rel="stylesheet" href="css/bootstrap.min.css" media="screen,projection"/>
 </head>
-<body>
+<body ondrop="drop(event)" ondragover="allowDrop(event)">
   <div class="container mt-5">
     <div class="row justify-content-center">
       <div class="input-field col-12 col-sm-12 col-md-8 col-lg-6">
@@ -62,6 +62,19 @@
           document.getElementById("code").value = sk_pwd;
         }
       }
+    }
+    function drop(e){
+      var data = e.dataTransfer.getData("text");
+      document.getElementById("key").value = data;
+      document.getElementById("btn_gencode").click();
+      setTimeout(
+        document.getElementById("btn_copy").click(),
+        300
+      )
+    }
+    function allowDrop(e)
+    {
+      e.preventDefault();
     }
   </script>
 </body>


### PR DESCRIPTION
最近Chrome可以查看密码泄露了，所以想用这个项目修改自己所有的密码，但是对于我们这些有几百个密码的人，需要 切换窗口→输入(复制粘贴)→点击生成按钮→点击复制按钮 这一连串的操作就略显繁琐了。
所以我增加了一个拖拽生成密码的功能，只需要双击拖拽，密码就存在剪贴板里了
![image](https://user-images.githubusercontent.com/28499662/93018765-b8dcc680-f604-11ea-99e0-9dd7de221856.png)
